### PR TITLE
feat: mark internal atoms as private

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "html-webpack-plugin": "^5.5.0",
     "jest": "^29.4.1",
     "jest-environment-jsdom": "^29.4.1",
-    "jotai": "^2.0.0",
+    "jotai": "https://pkg.csb.dev/pmndrs/jotai/commit/5e0c7f9e/jotai/_pkg.tgz",
     "microbundle": "^0.15.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.3",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "html-webpack-plugin": "^5.5.0",
     "jest": "^29.4.1",
     "jest-environment-jsdom": "^29.4.1",
-    "jotai": "https://pkg.csb.dev/pmndrs/jotai/commit/5e0c7f9e/jotai/_pkg.tgz",
+    "jotai": "^2.0.3",
     "microbundle": "^0.15.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.3",

--- a/src/atomWithStore.ts
+++ b/src/atomWithStore.ts
@@ -4,6 +4,7 @@ import type { StoreApi } from 'zustand/vanilla'
 
 export function atomWithStore<T>(store: StoreApi<T>) {
   const baseAtom = atom(store.getState())
+  baseAtom.debugPrivate = true
   baseAtom.onMount = (setValue) => {
     const callback = () => {
       setValue(store.getState())

--- a/src/atomWithStore.ts
+++ b/src/atomWithStore.ts
@@ -4,7 +4,10 @@ import type { StoreApi } from 'zustand/vanilla'
 
 export function atomWithStore<T>(store: StoreApi<T>) {
   const baseAtom = atom(store.getState())
-  baseAtom.debugPrivate = true
+  if (process.env.NODE_ENV !== 'production') {
+    baseAtom.debugPrivate = true
+  }
+
   baseAtom.onMount = (setValue) => {
     const callback = () => {
       setValue(store.getState())

--- a/yarn.lock
+++ b/yarn.lock
@@ -4990,10 +4990,9 @@ jest@^29.4.1:
     import-local "^3.0.2"
     jest-cli "^29.4.1"
 
-jotai@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/jotai/-/jotai-2.0.0.tgz#3938ad0166130417811bb57ec2de8abeb24bd948"
-  integrity sha512-04G0CRZQgp3xrFAezd6X14psZ2TRGekHeYMBcbDJ/BR8ZJQPS+j0YkMTxUxyG58HJnN2+adfj5sWQWoqgtp1XQ==
+"jotai@https://pkg.csb.dev/pmndrs/jotai/commit/5e0c7f9e/jotai/_pkg.tgz":
+  version "2.0.2"
+  resolved "https://pkg.csb.dev/pmndrs/jotai/commit/5e0c7f9e/jotai/_pkg.tgz#85bdb3e7a19daad7a3cbdc3b12eda7329b733222"
 
 js-sdsl@^4.1.4:
   version "4.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4990,9 +4990,10 @@ jest@^29.4.1:
     import-local "^3.0.2"
     jest-cli "^29.4.1"
 
-"jotai@https://pkg.csb.dev/pmndrs/jotai/commit/5e0c7f9e/jotai/_pkg.tgz":
-  version "2.0.2"
-  resolved "https://pkg.csb.dev/pmndrs/jotai/commit/5e0c7f9e/jotai/_pkg.tgz#85bdb3e7a19daad7a3cbdc3b12eda7329b733222"
+jotai@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/jotai/-/jotai-2.0.3.tgz#3b67cda9f6d5feb70a14db0b842a9873aacda8b5"
+  integrity sha512-MMjhSPAL3RoeZD9WbObufRT2quThEAEknHHridf2ma8Ml7ZVQmUiHk0ssdbR3F0h3kcwhYqSGJ59OjhPge7RRg==
 
 js-sdsl@^4.1.4:
   version "4.3.0"


### PR DESCRIPTION
### Checklist 

- [x] Check with Daishi if we should wrap the `debugPrivate` assignment in the dev-only flag now or do it later as it may require tooling changes
- [x] Update the `jotai` version to `2.0.3` once released